### PR TITLE
Fix. fingerprint login glitch

### DIFF
--- a/lib/app/view/app.dart
+++ b/lib/app/view/app.dart
@@ -3,13 +3,12 @@ import 'package:dairy_app/app/themes/coral_bubble_theme.dart';
 import 'package:dairy_app/app/themes/cosmic_theme.dart';
 import 'package:dairy_app/core/dependency_injection/injection_container.dart';
 import 'package:dairy_app/core/logger/logger.dart';
-import 'package:dairy_app/features/auth/data/models/user_config_model.dart';
+import 'package:dairy_app/core/pages/home_page.dart';
 import 'package:dairy_app/features/auth/presentation/bloc/auth_form/auth_form_bloc.dart';
 import 'package:dairy_app/features/auth/presentation/bloc/auth_session/auth_session_bloc.dart';
 import 'package:dairy_app/features/auth/presentation/bloc/cubit/theme_cubit.dart';
 import 'package:dairy_app/features/auth/presentation/bloc/user_config/user_config_cubit.dart';
 import 'package:dairy_app/features/auth/presentation/pages/auth_page.dart';
-import 'package:dairy_app/core/pages/home_page.dart';
 import 'package:dairy_app/features/notes/presentation/bloc/notes/notes_bloc.dart';
 import 'package:dairy_app/features/notes/presentation/bloc/notes_fetch/notes_fetch_cubit.dart';
 import 'package:dairy_app/features/notes/presentation/bloc/selectable_list/selectable_list_cubit.dart';
@@ -135,7 +134,6 @@ class _AppViewState extends State<AppView> {
               child: child,
             );
           },
-          initialRoute: AuthPage.route,
           onGenerateRoute: RouteGenerator.generateRoute,
         );
       },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
AuthPage widget was getting rendered two times, one from initial route, and second time from when a AuthSessionState state change happen in bloc listener. 
This was applied every time a app is opened and was not just specific to fingerprint handling.

## Fix
Removed initialRoute from the app, now it will build Auth Page one time, only after when all conditions are verified in Bloc Listener.

_Tested the Fix? 
- [X] In Real Device
- [X] In Emulator
## Related Tickets & Documents

- This fix will closes #16 
