### PR TITLE
[Binni] Fix. save note not working after delete (#38)

### DIFF
--- a/lib/features/notes/data/datasources/local data sources/local_data_source.dart
+++ b/lib/features/notes/data/datasources/local data sources/local_data_source.dart
@@ -72,7 +72,7 @@ class NotesLocalDataSource implements INotesLocalDataSource {
       result = await database.query(Notes.TABLE_NAME,
           columns: [Notes.ID, Notes.TITLE, Notes.PLAIN_TEXT, Notes.CREATED_AT],
           where:
-              "${Notes.DELETED} != 1 and ${Notes.AUTHOR_ID} = '$authorId' or ${Notes.AUTHOR_ID} = '${GuestUserDetails.guestUserId}'",
+              "${Notes.DELETED} != 1 and ( ${Notes.AUTHOR_ID} = '$authorId' or ${Notes.AUTHOR_ID} = '${GuestUserDetails.guestUserId}' )",
           orderBy: "${Notes.CREATED_AT} DESC");
     } catch (e) {
       log.e("Local database query for fetching notes preview failed $e");
@@ -89,7 +89,7 @@ class NotesLocalDataSource implements INotesLocalDataSource {
       result = await database.query(
         Notes.TABLE_NAME,
         where:
-            "${Notes.DELETED} != 1 and ${Notes.AUTHOR_ID} = '$authorId' or ${Notes.AUTHOR_ID} = '${GuestUserDetails.guestUserId}'",
+            "${Notes.DELETED} != 1 and ( ${Notes.AUTHOR_ID} = '$authorId' or ${Notes.AUTHOR_ID} = '${GuestUserDetails.guestUserId}' )",
       );
     } catch (e) {
       log.e("Local database query for fetching notes failed $e");
@@ -289,7 +289,7 @@ class NotesLocalDataSource implements INotesLocalDataSource {
     var result = await database.query(Notes.TABLE_NAME,
         columns: [Notes.ID],
         where:
-            "${Notes.DELETED} != 1 and ${Notes.AUTHOR_ID} = '$authorId' or ${Notes.AUTHOR_ID} = '${GuestUserDetails.guestUserId}'",
+            "${Notes.DELETED} != 1 and ( ${Notes.AUTHOR_ID} = '$authorId' or ${Notes.AUTHOR_ID} = '${GuestUserDetails.guestUserId}' )",
         orderBy: "${Notes.CREATED_AT} DESC");
 
     return result.map((noteMap) => noteMap["id"] as String).toList();
@@ -335,7 +335,7 @@ class NotesLocalDataSource implements INotesLocalDataSource {
         Notes.TABLE_NAME,
         columns: [Notes.ID, Notes.TITLE, Notes.PLAIN_TEXT, Notes.CREATED_AT],
         where:
-            "${Notes.DELETED} != 1 AND $searchQuery and ${Notes.AUTHOR_ID} = '$authorId' or ${Notes.AUTHOR_ID} = '${GuestUserDetails.guestUserId}'",
+            "${Notes.DELETED} != 1 AND $searchQuery and ( ${Notes.AUTHOR_ID} = '$authorId' or ${Notes.AUTHOR_ID} = '${GuestUserDetails.guestUserId}' )",
         orderBy: "${Notes.CREATED_AT} DESC",
       );
     } catch (e) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description/ RCA

The query used to fetch the notes was wrong. 

The query running previously was 
SELECT id, title, plain_text, created_at FROM Notes WHERE deleted != 1 and author_id = '17d8af20-6054-11ee-be82-b1b190fc05e2' or author_id = 'guest_user_id' ORDER BY created_at DESC'
This will select the notes even for which deleted is set to 1, because the operator precedence is wrong. 

## Fix

Changed the query and added brackets around author_id condition for precendency.
Now the query becomes: 

SELECT id, title, plain_text, created_at FROM Notes WHERE deleted != 1 and (author_id = '17d8af20-6054-11ee-be82-b1b190fc05e2' or author_id = 'guest_user_id') ORDER BY created_at DESC'


## Related Tickets & Documents

- Closes #38 


## Tested Feature??

- [X] In Real Device.
- [X] In Emulator

@SankethBK could you please review it