### PR TITLE
Pasting images by link is not working fix

### DIFF
--- a/packages/flutter_quill/flutter_quill_extensions/lib/embeds/toolbar/image_video_utils.dart
+++ b/packages/flutter_quill/flutter_quill_extensions/lib/embeds/toolbar/image_video_utils.dart
@@ -61,9 +61,9 @@ class LinkDialogState extends State<LinkDialog> {
               : null,
           child: Text(
             'Ok'.i18n,
-             style: widget.dialogTheme?.labelTextStyle == null ?
-             TextStyle(color: Colors.black) :
-             widget.dialogTheme?.labelTextStyle,
+            style: widget.dialogTheme?.labelTextStyle == null
+                ? TextStyle(color: Colors.black)
+                : widget.dialogTheme?.labelTextStyle,
           ),
         ),
       ],

--- a/packages/flutter_quill/flutter_quill_extensions/lib/embeds/toolbar/image_video_utils.dart
+++ b/packages/flutter_quill/flutter_quill_extensions/lib/embeds/toolbar/image_video_utils.dart
@@ -61,7 +61,9 @@ class LinkDialogState extends State<LinkDialog> {
               : null,
           child: Text(
             'Ok'.i18n,
-            style: widget.dialogTheme?.labelTextStyle,
+             style: widget.dialogTheme?.labelTextStyle == null ?
+             TextStyle(color: Colors.black) :
+             widget.dialogTheme?.labelTextStyle,
           ),
         ),
       ],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The Text widget inside the TextButton has a style of widget.dialogTheme?.labelTextStyle. This is null sometimes, hence no style is applied. Therefore, the Ok button disappears.

## Featured Covered in this PR

- [X] Adding ternary clause to handle case where labelTextStyle is null

## Related Tickets & Documents

Closes #69 

## Screenshots, Recordings

![qemu-system-x86_64_UbvFQPm5t1](https://github.com/SankethBK/diaryvault/assets/23402988/f8cce516-013c-4c85-bac5-dcc3bad6d436)

## Tested Feature??

- [ ] In Real Device.
- [X] In Emulator
