### PR TITLE
fix: handle scheduling permission request

### DIFF
--- a/lib/features/notes/data/repositories/notifications_repository.dart
+++ b/lib/features/notes/data/repositories/notifications_repository.dart
@@ -76,12 +76,19 @@ class NotificationsRepository implements INotificationsRepository {
   }
 
   Future<bool> areNotificationsEnabled() async {
-    final bool granted = await flutterLocalNotificationsPlugin
+    final bool notificationAllowed = await flutterLocalNotificationsPlugin
             .resolvePlatformSpecificImplementation<
                 AndroidFlutterLocalNotificationsPlugin>()
             ?.areNotificationsEnabled() ??
         false;
-    return granted;
+
+    final bool scheduleAllowed = await flutterLocalNotificationsPlugin
+            .resolvePlatformSpecificImplementation<
+                AndroidFlutterLocalNotificationsPlugin>()
+            ?.canScheduleExactNotifications() ??
+        false;
+
+    return notificationAllowed && scheduleAllowed;
   }
 
   Future<bool> requestPermission() async {
@@ -92,7 +99,10 @@ class NotificationsRepository implements INotificationsRepository {
     final bool grantedNotificationPermission =
         await androidImplementation?.requestNotificationsPermission() ?? false;
 
-    return grantedNotificationPermission;
+    final bool allowedSchedulingPermission =
+        await androidImplementation?.requestExactAlarmsPermission() ?? false;
+
+    return grantedNotificationPermission && allowedSchedulingPermission;
   }
 
   @override


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
To schedule notification on exact time, user should manually allow the alarm permission. The request for this was not made so it failed when tried to turn on the scheduling toggle.

## Featured Covered in this PR

- [x] Request for alarm permission


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Screenshots, Recordings

<img width="732" alt="image" src="https://github.com/user-attachments/assets/8881f1f3-6eb4-44f6-8b20-0a173c5d2583">

*Please replace this line with instructions on how to test your changes, or any screenshots or recording you can attach here.*

## Tested Feature??

- [x] In Real Device.
- [ ] In Emulator
