### PR TITLE
Fix NextCloud isSignedIn return value

### DIFF
--- a/lib/features/sync/data/datasources/nextcloud_sync_client.dart
+++ b/lib/features/sync/data/datasources/nextcloud_sync_client.dart
@@ -223,7 +223,7 @@ class NextCloudSyncClient extends ISyncClient {
       rethrow;
     }
 
-    return false;
+    return true;
   }
 
   @override


### PR DESCRIPTION
## Summary
- ensure NextCloud `isSignedIn` returns true when ping succeeds

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e35c78790832cb172a9a8deeb49d1