### PR TITLE
Implement Data Source Changes for Smart Folders

### DIFF
--- a/lib/core/databases/db_schemas.dart
+++ b/lib/core/databases/db_schemas.dart
@@ -48,4 +48,5 @@ class SmartFolders {
   static const FOLDER_NAME = "folder_name";
   static const FOLDER_TAGS = "folder_tags";
   static const CREATED_AT = "created_at";
+  static const AUTHOR_ID = "author_id";
 }

--- a/lib/core/databases/db_schemas.dart
+++ b/lib/core/databases/db_schemas.dart
@@ -39,3 +39,13 @@ class Tags {
   static const NOTE_ID = "note_id";
   static const NAME = "name";
 }
+
+class SmartFolders {
+  static const TABLE_NAME = "Smart_folders";
+
+  // Columns
+  static const FOLDER_ID = "folder_id";
+  static const FOLDER_NAME = "folder_name";
+  static const FOLDER_TAGS = "folder_tags";
+  static const CREATED_AT = "created_at";
+}

--- a/lib/core/databases/sqflite_setup.dart
+++ b/lib/core/databases/sqflite_setup.dart
@@ -73,7 +73,8 @@ class DBProvider {
             ${SmartFolders.FOLDER_ID} TEXT, 
             ${SmartFolders.CREATED_AT} DATETIME,
             ${SmartFolders.FOLDER_NAME} TEXT,
-            ${SmartFolders.FOLDER_TAGS} TEXT
+            ${SmartFolders.FOLDER_TAGS} TEXT,
+            ${SmartFolders.AUTHOR_ID} TEXT
           )
           """);
 
@@ -116,7 +117,8 @@ class DBProvider {
             ${SmartFolders.FOLDER_ID} TEXT, 
             ${SmartFolders.CREATED_AT} DATETIME,
             ${SmartFolders.FOLDER_NAME} TEXT,
-            ${SmartFolders.FOLDER_TAGS} TEXT
+            ${SmartFolders.FOLDER_TAGS} TEXT,
+            ${SmartFolders.AUTHOR_ID} TEXT
           )
           """);
         }

--- a/lib/core/databases/sqflite_setup.dart
+++ b/lib/core/databases/sqflite_setup.dart
@@ -26,7 +26,7 @@ class DBProvider {
     String path = join(documentsDirectory.path, "prod.db");
     return await openDatabase(
       path,
-      version: 2,
+      version: 3,
       onOpen: (db) {},
       onCreate: (Database db, int version) async {
         try {
@@ -68,6 +68,15 @@ class DBProvider {
               ${Tags.NAME} TEXT
             )""");
 
+          await db.execute("""
+          CREATE TABLE ${SmartFolders.TABLE_NAME} (
+            ${SmartFolders.FOLDER_ID} TEXT, 
+            ${SmartFolders.CREATED_AT} DATETIME,
+            ${SmartFolders.FOLDER_NAME} TEXT,
+            ${SmartFolders.FOLDER_TAGS} TEXT
+          )
+          """);
+
           log.i("All create queries executed successfully");
           log.i("Inserting welcome note");
 
@@ -99,6 +108,17 @@ class DBProvider {
               ${Tags.NOTE_ID} TEXT,
               ${Tags.NAME} TEXT
             )""");
+        }
+
+        if (oldVersion < 3) {
+          await db.execute("""
+          CREATE TABLE ${SmartFolders.TABLE_NAME} (
+            ${SmartFolders.FOLDER_ID} TEXT, 
+            ${SmartFolders.CREATED_AT} DATETIME,
+            ${SmartFolders.FOLDER_NAME} TEXT,
+            ${SmartFolders.FOLDER_TAGS} TEXT
+          )
+          """);
         }
       },
     );

--- a/lib/features/notes/data/datasources/local data sources/local_data_source.dart
+++ b/lib/features/notes/data/datasources/local data sources/local_data_source.dart
@@ -463,7 +463,7 @@ class NotesLocalDataSource implements INotesLocalDataSource {
   //* Utils
 
   /// Generate a modifiable result set
-  List<Map<String, dynamic>> makeModifiableResults(
+  static List<Map<String, dynamic>> makeModifiableResults(
       List<Map<String, dynamic>> results) {
     // Generate modifiable
     return List<Map<String, dynamic>>.generate(

--- a/lib/features/smart_folders/data/datasources/local_data_sources/local_data_source.dart
+++ b/lib/features/smart_folders/data/datasources/local_data_sources/local_data_source.dart
@@ -1,0 +1,261 @@
+import 'dart:io';
+
+import 'package:dairy_app/core/databases/db_schemas.dart';
+import 'package:dairy_app/core/databases/sqflite_setup.dart';
+import 'package:dairy_app/core/errors/database_exceptions.dart';
+import 'package:dairy_app/features/auth/core/constants.dart';
+import 'package:dairy_app/features/smart_folders/data/datasources/local_data_sources/local_data_source_template.dart';
+import 'package:dairy_app/features/smart_folders/data/models/smart_folders_model.dart';
+import 'package:sqflite/sqflite.dart';
+import '../../../../../core/logger/logger.dart';
+import '../../../../notes/data/datasources/local data sources/local_data_source.dart';
+import '../../../../notes/data/models/notes_model.dart';
+
+final log = printer("SmartFoldersLocalDataSource");
+
+class SmartFoldersLocalDataSource implements ISmartFoldersLocalDataSource {
+  static late Database database;
+
+  SmartFoldersLocalDataSource._();
+
+  static create() async {
+    database = await DBProvider.instance.database;
+    return SmartFoldersLocalDataSource._();
+  }
+
+  @override
+  Future<void> saveSmartFolder(Map<String, dynamic> smartFolderMap) async {
+    // Insert smart folder
+    log.i("Starting to insert smart folder ${smartFolderMap["folder_id"]} into db");
+
+    try {
+      var res = await database.insert(SmartFolders.TABLE_NAME, smartFolderMap);
+
+      if (res == -1) {
+        log.e("database insertion for ${smartFolderMap["folder_id"]} unsuccessful");
+        throw const DatabaseInsertionException("Smart folder insertion failed");
+      }
+    } catch (e) {
+      log.e(e);
+      rethrow;
+    }
+
+    log.i("Smart folder ${smartFolderMap["folder_id"]} inserted into db");
+  }
+
+  @override
+  Future<List<SmartFolderModel>> fetchSmartFolders({required String authorId, List<String>? folderIds}) async {
+    log.i("Starting to fetch smart folders of $authorId into db");
+    List<Map<String, dynamic>> result;
+
+    try {
+      if (folderIds != null && folderIds.isNotEmpty) {
+        // Format the folderIds list for the SQL query
+        String folderIdsString = folderIds.map((id) => "'$id'").join(', ');
+
+        result = await database.query(
+          SmartFolders.TABLE_NAME,
+          where:
+          "( ${SmartFolders.AUTHOR_ID} = '$authorId' or ${SmartFolders.AUTHOR_ID} = '${GuestUserDetails.guestUserId}' ) AND ${SmartFolders.FOLDER_ID} IN ($folderIdsString)",
+        );
+      } else {
+        result = await database.query(
+          SmartFolders.TABLE_NAME,
+          where:
+          "( ${SmartFolders.AUTHOR_ID} = '$authorId' or ${SmartFolders.AUTHOR_ID} = '${GuestUserDetails.guestUserId}' )",
+        );
+      }
+    } catch (e) {
+      log.e("Local database query for fetching notes failed $e");
+      throw const DatabaseQueryException();
+    }
+
+    log.i("Fetch smart folders of $authorId successful");
+    return result.map((folderMap) => SmartFolderModel.fromJson(folderMap)).toList();
+  }
+
+  @override
+  Future<SmartFolderModel> getSmartFolder(String id, String authorId) async {
+    // TODO: use authorId or not?
+    log.i("Starting get smart folders $id");
+
+    var result = await database
+        .query(SmartFolders.TABLE_NAME, where: "${SmartFolders.FOLDER_ID} = ?", whereArgs: [id]);
+    if (result.isEmpty) {
+      log.e("Smart folders with id: $id not found");
+      throw const DatabaseQueryException();
+    }
+    log.i("get folder successful, folder id: $id");
+
+    return SmartFolderModel.fromJson(result.first);
+  }
+
+  @override
+  Future<void> updateSmartFolder(Map<String, dynamic> smartFolderMap, String authorId) async {
+    // store id
+    log.i("Starting update smart folder ${smartFolderMap["folder_id"]}");
+
+    var id = smartFolderMap["folder_id"];
+    smartFolderMap.remove("folder_id");
+
+    // No "last_updated" column so no need to update it to now
+    var count = await database.update(SmartFolders.TABLE_NAME,
+        {...smartFolderMap},
+        where: "${SmartFolders.FOLDER_ID} = ?", whereArgs: [id]);
+
+    if (count != 1) {
+      log.e("smart folder update failed for id: $id");
+      throw const DatabaseUpdateException();
+    }
+
+    log.i("update smart folder successful for id: $id");
+  }
+
+  @override
+  Future<void> deleteSmartFolder(String id, String authorId) async {
+    // No difference between soft/hard deletion here
+    log.i("Starting deletion of smart folder $id");
+
+    var count = await database
+        .delete(SmartFolders.TABLE_NAME, where: "${SmartFolders.FOLDER_ID} = ?", whereArgs: [id]);
+    if (count != 1) {
+      log.e("Smart folder deletion unsuccessful for folder id: $id");
+      throw const DatabaseDeleteException();
+    }
+
+    log.i("Smart folder (hard) deletion successful for folder id: $id");
+  }
+
+  @override
+  Future<List<String>> getAllSmartFolderIds(String authorId) async {
+    log.i("Starting getAll smart folder for $authorId");
+
+    var result = await database.query(SmartFolders.TABLE_NAME,
+        columns: [SmartFolders.FOLDER_ID],
+        where:
+        "( ${SmartFolders.AUTHOR_ID} = '$authorId' or ${SmartFolders.AUTHOR_ID} = '${GuestUserDetails.guestUserId}' )",
+        orderBy: "${SmartFolders.CREATED_AT} DESC");
+
+    log.i("getAll smart folder successful");
+    return result.map((folderMap) => folderMap["folder_id"] as String).toList();
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> getSmartFolderIndex(String authorId) async {
+    var allNotesIndex = await database.query(SmartFolders.TABLE_NAME,
+        where:
+        "${SmartFolders.AUTHOR_ID} = '$authorId' or ${SmartFolders.AUTHOR_ID} = '${GuestUserDetails.guestUserId}'",
+        orderBy: "${SmartFolders.CREATED_AT} DESC");
+
+    return NotesLocalDataSource.makeModifiableResults(allNotesIndex).map((note) {
+      return note;
+    }).toList();
+  }
+
+  @override
+  Future<List<SmartFolderModel>> searchSmartFolders(String authorId, {String? searchText, DateTime? startDate, DateTime? endDate, List<String>? tags}) async {
+    log.i("Searching for smart folders");
+    List<Map<String, Object?>> result;
+
+    String searchQuery = "(${SmartFolders.FOLDER_NAME} LIKE '%${searchText ?? ''}%')";
+
+    // Add start date requirement if it exists
+    if (startDate != null) {
+      String startDateStr = startDate.millisecondsSinceEpoch.toString();
+      searchQuery += " AND (${SmartFolders.CREATED_AT} >= '$startDateStr')";
+    }
+
+    // Add end date requirement if it exists
+    if (endDate != null) {
+      String endDateStr = endDate.millisecondsSinceEpoch.toString();
+      searchQuery += " AND (${SmartFolders.CREATED_AT} <= '$endDateStr')";
+    }
+
+    try {
+      // Add tag requirement if it exists
+      if (tags != null && tags.isNotEmpty) {
+        // FolderID's with matching tags
+        List<String> folderIds = [];
+
+        for (String tagName in tags) {
+          final tagResult = await database.query(
+            SmartFolders.TABLE_NAME,
+            columns: [SmartFolders.FOLDER_ID],
+            where: "${SmartFolders.FOLDER_TAGS} LIKE ?",
+            whereArgs: ["%" + tagName + "%"],
+          );
+
+          // Add folder ID to requirement if there is a match (ignore tag requirement if no match at all)
+          for (var tagMap in tagResult) {
+            if (tagMap[SmartFolders.FOLDER_ID] != null) {
+              final folderID = tagMap[SmartFolders.FOLDER_ID] as String;
+              folderIds.add("'$folderID'");
+            }
+          }
+        }
+
+        if (folderIds.isNotEmpty) {
+          searchQuery += " AND ${SmartFolders.FOLDER_ID} IN (${folderIds.join(", ")})";
+        }
+      }
+
+      log.i("searchQuery = $searchQuery");
+
+      result = await database.query(
+        SmartFolders.TABLE_NAME,
+        where:
+        "$searchQuery and ( ${SmartFolders.AUTHOR_ID} = '$authorId' or ${SmartFolders.AUTHOR_ID} = '${GuestUserDetails.guestUserId}' )",
+        orderBy: "${SmartFolders.CREATED_AT} DESC",
+      );
+
+    } catch (e) {
+      log.e("Local database query for searching notes failed $e");
+      throw const DatabaseQueryException();
+    }
+
+    log.i("Search for smart folders successful");
+    return result.map((folderMap) => SmartFolderModel.fromJson(folderMap)).toList();
+  }
+
+  @override
+  Future<List<NoteModel>> fetchSmartFolderContent(String id, String authorId) async {
+    // Returns all notes that contain at least one matching tag
+    log.i("Fetching the content of smart folder $id");
+    SmartFolderModel smartFolder = await getSmartFolder(id, authorId);
+    List<Map<String, dynamic>> result;
+
+    // NodeID's with matching tags
+    List<String> NoteIds = [];
+    for (var tagName in smartFolder.folder_tags) {
+      final tagResult = await database.query(
+        Tags.TABLE_NAME,
+        columns: [Tags.NOTE_ID],
+        where: "${Tags.NAME} = ?",
+        whereArgs: [tagName],
+      );
+
+      for (var tagMap in tagResult) {
+        if (tagMap[Tags.NOTE_ID] != null) {
+          final folderID = tagMap[Tags.NOTE_ID] as String;
+          NoteIds.add("'$folderID'");
+        }
+      }
+    }
+
+    try {
+      String NoteIdsString = NoteIds.join(", ");
+
+      result = await database.query(Notes.TABLE_NAME,
+        where:
+        "${Notes.DELETED} != 1 and ( ${Notes.AUTHOR_ID} = '$authorId' or ${Notes.AUTHOR_ID} = '${GuestUserDetails.guestUserId}' ) AND ${Notes.ID} IN ($NoteIdsString)",
+        orderBy: "${Notes.CREATED_AT} DESC"
+      );
+
+    } catch (e) {
+      log.e("Local database query for fetching smart folder content failed $e");
+      throw const DatabaseQueryException();
+    }
+
+    return result.map((noteMap) => NoteModel.fromJson(noteMap)).toList();
+  }
+}

--- a/lib/features/smart_folders/data/datasources/local_data_sources/local_data_source_template.dart
+++ b/lib/features/smart_folders/data/datasources/local_data_sources/local_data_source_template.dart
@@ -1,0 +1,46 @@
+import 'package:dairy_app/features/notes/data/models/notes_model.dart';
+import 'package:dairy_app/features/smart_folders/data/models/smart_folders_model.dart';
+
+abstract class ISmartFoldersLocalDataSource {
+  /// Saves smart folder as new record in database
+  ///
+  /// Throws [DatabaseInsertionException] if something goes wrong
+  Future<void> saveSmartFolder(Map<String, dynamic> smartFolderMap);
+
+  /// Fetches all smart folders
+  ///
+  /// Throws [DatabaseQueryException] if something goes wrong
+  Future<List<SmartFolderModel>> fetchSmartFolders(
+      {required String authorId, List<String>? folderIds});
+
+  /// Fetches the smart folder with given id
+  ///
+  /// Throws [DatabaseQueryException] if something goes wrong
+  Future<SmartFolderModel> getSmartFolder(String id, String authorId);
+
+  /// Updates the smart folder using its id present in model
+  ///
+  /// Throws [DatabaseUpdateException] if something goes wrong
+  Future<void> updateSmartFolder(Map<String, dynamic> smartFolderMap, String authorId);
+
+  /// Deletes the smart folder from id
+  ///
+  /// Throws [DatabaseDeleteException] if something goes wrong
+  Future<void> deleteSmartFolder(String id, String authorId);
+
+  /// Returns all SmartFolder ID's
+  Future<List<String>> getAllSmartFolderIds(String authorId);
+
+  /// Generates SmartFolder index for all folders, used for syncing to cloud
+  Future<List<Map<String, dynamic>>> getSmartFolderIndex(String authorId);
+
+  /// Search smart folders based on searchText, startDate and endDate
+  Future<List<SmartFolderModel>> searchSmartFolders(String authorId,
+      {String? searchText,
+        DateTime? startDate,
+        DateTime? endDate,
+        List<String>? tags});
+
+  /// Fetches all notes that are inside a specific smart folder (containing at least one of their tags)
+  Future<List<NoteModel>> fetchSmartFolderContent(String id, String authorId);
+}

--- a/lib/features/smart_folders/data/models/smart_folders_model.dart
+++ b/lib/features/smart_folders/data/models/smart_folders_model.dart
@@ -1,0 +1,40 @@
+import 'dart:convert';
+
+import '../../domain/entities/smart_folders.dart';
+
+class SmartFolderModel extends SmartFolder {
+  @override
+  final List<String> folder_tags;
+
+  const SmartFolderModel({
+    required String folder_id,
+    required DateTime createdAt,
+    required String folder_name,
+    required this.folder_tags,
+    String? authorId
+  }) : super(
+      folder_id: folder_id,
+    createdAt: createdAt,
+    folder_name: folder_name,
+    folder_tags: folder_tags,
+    authorId: authorId
+  );
+
+  factory SmartFolderModel.fromJson(Map<String, dynamic> jsonMap) {
+    return SmartFolderModel(
+      folder_id: jsonMap["folder_id"],
+      createdAt: DateTime.fromMillisecondsSinceEpoch(jsonMap["created_at"]),
+      folder_name: jsonMap["folder_name"],
+      folder_tags: List<String>.from(jsonDecode(jsonMap["folder_tags"])) ?? [],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      "folder_id": folder_id,
+      "created_at": createdAt.millisecondsSinceEpoch,
+      "folder_name": folder_name,
+      "folder_tags": jsonEncode(folder_tags)
+    };
+  }
+}

--- a/lib/features/smart_folders/domain/entities/smart_folders.dart
+++ b/lib/features/smart_folders/domain/entities/smart_folders.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+
+import 'package:equatable/equatable.dart';
+
+class SmartFolder extends Equatable {
+  final String folder_id;
+  final DateTime createdAt;
+  final String folder_name;
+  final List<String> folder_tags;
+  final String? authorId;
+
+  const SmartFolder({
+    required this.folder_id,
+    required this.createdAt,
+    required this.folder_name,
+    required this.folder_tags,
+    this.authorId
+  });
+
+  String getHashingString() {
+    return folder_name + createdAt.toString() + folder_tags.join(",");
+  }
+
+  @override
+  List<Object> get props {
+    return [
+      folder_id,
+      createdAt,
+      folder_name,
+      folder_tags
+    ];
+  }
+
+  @override
+  String toString() {
+    return 'SmartFolder(folder_id: $folder_id, createdAt: $createdAt, folder_name: $folder_name, folder_tags: ' + jsonEncode(folder_tags) + ', authorId: $authorId))';
+  }
+}

--- a/test/features/smart_folders/domain/smart_folder_entities_test.dart
+++ b/test/features/smart_folders/domain/smart_folder_entities_test.dart
@@ -1,0 +1,70 @@
+import 'package:dairy_app/features/smart_folders/data/models/smart_folders_model.dart';
+import 'package:test/test.dart';
+
+
+void main() {
+  test('Testing smart folder conversion to string and to Json', () {
+
+    final smartFolder = SmartFolderModel(
+        folder_id: 'a873a170-6447-11ee-9a76-c314b6be99a5',
+        createdAt: DateTime.fromMillisecondsSinceEpoch(1726597075215),
+        folder_name: 'MySmartFolder',
+        folder_tags: ["abc","def"]
+    );
+
+    // Convert to String
+    expect(smartFolder.toString(),'SmartFolder(folder_id: a873a170-6447-11ee-9a76-c314b6be99a5, createdAt: 2024-09-17 20:17:55.215, folder_name: MySmartFolder, folder_tags: ["abc","def"], authorId: null))');
+
+    // Convert to Json
+    expect(smartFolder.toJson().toString(), '{folder_id: a873a170-6447-11ee-9a76-c314b6be99a5, created_at: 1726597075215, folder_name: MySmartFolder, folder_tags: ["abc","def"]}');
+
+    // Convert to Json then back to SmartFolderModel and verify they are considered equal
+    expect(SmartFolderModel.fromJson(smartFolder.toJson()) == smartFolder, true);
+  });
+
+  test('Testing equality between two smart folders', () {
+
+    final smartFolder = SmartFolderModel(
+        folder_id: 'a873a170-6447-11ee-9a76-c314b6be99a5',
+        createdAt: DateTime.fromMillisecondsSinceEpoch(1726597075215),
+        folder_name: 'MySmartFolder',
+        folder_tags: ["abc","def"]
+    );
+
+    final identicalSmartFolder = SmartFolderModel(
+        folder_id: 'a873a170-6447-11ee-9a76-c314b6be99a5',
+        createdAt: DateTime.fromMillisecondsSinceEpoch(1726597075215),
+        folder_name: 'MySmartFolder',
+        folder_tags: ["abc","def"]
+    );
+
+    expect(smartFolder == smartFolder, true); // identical references
+    expect(smartFolder == identicalSmartFolder, true); // different references, same content
+
+    final differentName = SmartFolderModel(
+        folder_id: 'a873a170-6447-11ee-9a76-c314b6be99a5',
+        createdAt: DateTime.fromMillisecondsSinceEpoch(1726597075215),
+        folder_name: 'NotMySmartFolder',
+        folder_tags: ["abc","def"]
+    );
+
+    final differentTags = SmartFolderModel(
+        folder_id: 'a873a170-6447-11ee-9a76-c314b6be99a5',
+        createdAt: DateTime.fromMillisecondsSinceEpoch(1726597075215),
+        folder_name: 'MySmartFolder',
+        folder_tags: ["lorem"]
+    );
+
+    final differentID = SmartFolderModel(
+        folder_id: 'AAAAAA-6447-11ee-9a76-c314b6be99a5',
+        createdAt: DateTime.fromMillisecondsSinceEpoch(1726597075215),
+        folder_name: 'MySmartFolder',
+        folder_tags: ["abc","def"]
+    );
+
+    expect(smartFolder == differentName, false);
+    expect(smartFolder == differentTags, false);
+    expect(smartFolder == differentID, false);
+
+  });
+}


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [x] Documentation Update

## Description
I implemented all the database and API changes required to make smart folders work. However, I have not modified the UI.

## Features covered in this PR

- [x] Create a New Table: smart_folders
  - This table contains the folder ID, folder name, folder tags, creation time, author ID
  - It does not contain a deleted flag as discussed in the issue
- [x] Set Up Models and Entities
  - I added some unit tests related to that part (see below)
- [x] Define the Data Source Interface
  - I followed the logic of notes, with the important addition of `fetchSmartFolderContent` in preparation for future work
  - `deleteSmartFolder` makes no difference between soft/hard deletion since there is no delete flag.
- [x] Implement the Local Data Source
  - `searchSmartFolders`'s tag filter will match any folder who contains any of the given tags. However, if no folder matches the tag, the tag filter will be ignored. This behaviour is consistent with `searchNotes`.
  - `getSmartFolder` receives author ID as argument but does not use it for now to be consistent with `getNote`. Let me know if this behaviour should be changed.
  - I don't fully understand what `getSmartFolderIndex` is for, but I followed the same logic as for notes.
- [ ] Add Smart Folders Section to Home Page
- [ ] Implement Blocs and Cubits
- [ ] Design the Smart Folders List Page
- [ ] Create Smart Folder Creation Popup 


## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #219 

## Screenshots, Recordings
To test changes, run the main function in `test\features\smart_folders\domain\smart_folder_entities_test.dart`

<img width="1803" height="654" alt="image" src="https://github.com/user-attachments/assets/36630df5-8285-4ca6-9253-0e5de6a855cd" />


I would have liked to add unit tests for the SQLite queries, but I have no idea how to do them with Flutter so I tested them manually instead with a debug button in local files. They seemed to behave as expected.

## Testes done with

- [x] Real Device
- [x] Unit tests (for entities) 
- [ ] Emulator
